### PR TITLE
move react dependency to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     ]
   },
   "dependencies": {
-    "envify": "^1.2.1",
-    "react": "^0.10.0"
   },
   "devDependencies": {
+    "envify": "^1.2.1",
+    "react": "^0.10.0",
     "css-loader": "^0.6.12",
     "gulp": "^3.6.2",
     "gulp-rename": "^1.2.0",


### PR DESCRIPTION
react should not be dependency for a react-base library. move react to devDependencies.